### PR TITLE
typo fix

### DIFF
--- a/projects/v2/src/app/components/report/report.component.html
+++ b/projects/v2/src/app/components/report/report.component.html
@@ -153,7 +153,7 @@
                 <p class="text-muted mb-3">
                   <small class="font-weight-normal">Counts by Organ</small>
                 </p>
-                <div class="display-option" #tooltip="matTooltip" matTooltip="Exoport as Xlsx">
+                <div class="display-option" #tooltip="matTooltip" matTooltip="Export as Xlsx">
                   <button mat-icon-button 
                    (click)="downloadReportByOrgan()" 
                    class="mr-2" >


### PR DESCRIPTION
On hover on download button, tool tip description had typographical error.