### PR TITLE
Add main bronchus and trachea ASCT+B table gid

### DIFF
--- a/projects/v2/src/assets/sheet-config.json
+++ b/projects/v2/src/assets/sheet-config.json
@@ -663,6 +663,26 @@
         "viewValue": "v1.3 DRAFT"
       }
     ],
+         "title": "Anatomical Structures",
+    "data": ""
+  },
+  {
+    "name": "main-bronchus",
+    "display": "Main Bronchus",
+    "config": {
+      "bimodal_distance_x": 250,
+      "bimodal_distance_y": 60,
+      "width": 700,
+      "height": 2250
+    },
+    "version": [
+      {
+        "sheetId": "1VstIfAHSehrY5MNeTlNtRlOHtbQN8psru5rl5vglPxA",
+        "gid": "0",
+        "value": "main-bronchus-v1.0-DRAFT",
+        "viewValue": "v1.0 DRAFT"
+      }
+    ],
     "title": "Anatomical Structures",
     "data": ""
   },
@@ -1171,6 +1191,26 @@
         "gid": "863370556",
         "value": "thymus-v1.4-DRAFT",
         "viewValue": "v1.4 DRAFT"
+      }
+    ],
+       "title": "Anatomical Structures",
+    "data": ""
+  },
+  {
+    "name": "trachea",
+    "display": "Trachea",
+    "config": {
+      "bimodal_distance_x": 250,
+      "bimodal_distance_y": 60,
+      "width": 700,
+      "height": 2250
+    },
+    "version": [
+      {
+        "sheetId": "1fQK7XcXugC8eJZQyviNLevEUMoDT6cxxWp2AuH2gyws",
+        "gid": "0",
+        "value": "trachea-v1.0-DRAFT",
+        "viewValue": "v1.0 DRAFT"
       }
     ],
     "title": "Anatomical Structures"


### PR DESCRIPTION
Added main bronchus and trachea tables in alphabetical order: 
       "title": "Anatomical Structures",
    "data": ""
  },
  {
    "name": "main-bronchus",
    "display": "Main Bronchus",
    "config": {
      "bimodal_distance_x": 250,
      "bimodal_distance_y": 60,
      "width": 700,
      "height": 2250
    },
    "version": [
      {
        "sheetId": "1VstIfAHSehrY5MNeTlNtRlOHtbQN8psru5rl5vglPxA",
        "gid": "0",
        "value": "main-bronchus-v1.0-DRAFT",
        "viewValue": "v1.0 DRAFT"
      }
    ],
    "title": "Anatomical Structures",
    "data": ""
  },
  {
    "name": "trachea",
    "display": "Trachea",
    "config": {
      "bimodal_distance_x": 250,
      "bimodal_distance_y": 60,
      "width": 700,
      "height": 2250
    },
    "version": [
      {
        "sheetId": "1fQK7XcXugC8eJZQyviNLevEUMoDT6cxxWp2AuH2gyws",
        "gid": "0",
        "value": "trachea-v1.0-DRAFT",
        "viewValue": "v1.0 DRAFT"
      }
    ],