### PR TITLE
updated draft tables, added uberon IDs

### DIFF
--- a/projects/v2/src/assets/sheet-config.json
+++ b/projects/v2/src/assets/sheet-config.json
@@ -321,8 +321,8 @@
         "hraVersion": "v1.4"
       },
        {
-        "sheetId": "",
-        "gid": "",
+        "sheetId": "1tNNPZXL0ycw5gNksDUKHZJpRkKgRdVAUh9AZ6ohpgOA",
+        "gid": "695483621",
         "value": "eye-v1.4_DRAFT",
         "viewValue": "v1.4"
       }

--- a/projects/v2/src/assets/sheet-config.json
+++ b/projects/v2/src/assets/sheet-config.json
@@ -52,25 +52,27 @@
       "width": 500,
       "height": 500
     },
-    "representation_of": [],
-    "title": "Anatomical Structures"
+    
+   
+    "title": "Anatomical Structures",
+    "data": ""
   },
   {
-    "name": "adipose",
-    "display": "Adipose",
+    "name": "anatomical_systems",
+    "display": "Anatomical Systems",
     "config": {
       "bimodal_distance_x": 250,
       "bimodal_distance_y": 60,
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000467"],
     "version": [
       {
-        "sheetId": "13ov5MlglQ2mqy8Xl3Hyp4aH2dx1P7Uc4efM4RZqi5DI",
-        "gid": "0",
-        "value": "adipose-v1.0-DRAFT",
-        "viewValue": "v1.0 DRAFT"
+        "sheetId": "1oB3m_IOMEcDsdQoDicXd9KXXz7oytIPIPiu9lq88quU",
+        "gid": "2028977062",
+        "value": "anatomical-systems-DRAFT-v1.0",
+        "viewValue": "v1.0"
       }
     ],
     "title": "Anatomical Structures",
@@ -85,7 +87,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000178"],
     "version": [
       {
         "sheetId": "1ZYcSWnFHmzR9XKy_002f_oA4PfzokiW4IxkaZZOusvg",
@@ -127,7 +129,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0004537"],
     "version": [
       {
         "sheetId": "1P4PPdZb1WaooBf2HYk8ySUTicbb98xISnC2v5Pzyvpc",
@@ -163,7 +165,13 @@
         "value": "Blood-Vasculature-v1.4",
         "viewValue": "v1.4",
         "hraVersion": "v1.4"
-      }
+      },
+      {
+        "sheetId": "1QWQTFlQWOzPj42jqhKFWbuOU1ZUkpCJ657LddCH0Bfw",
+        "gid": "1958526503",
+        "value": "Blood-Vasculature-v1.5_DRAFT",
+        "viewValue": "v1.5"
+      }  
     ],
     "title": "Anatomical Structures",
     "data": ""
@@ -177,7 +185,7 @@
       "width": 500,
       "height": 1000
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002371"],
     "version": [
       {
         "sheetId": "1lfZKW0cMYifC_cf3KGDf8zuJiYSx7B7D3Ux0IcanoZQ",
@@ -226,7 +234,7 @@
       "width": 800,
       "height": 5000
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000955"],
     "version": [
       {
         "sheetId": "18J89Ir5HWStCrTWKhGNnh3aPOy5UZ5HFZFcCzBfWmGA",
@@ -262,7 +270,13 @@
         "value": "brain-v1.4",
         "viewValue": "v1.4",
         "hraVersion": "v1.4"
-      }
+      },
+      {
+        "sheetId": "1DrsZo9QUgnye6qX9hGKQoXVruRbM3LZPT2tzUy-SixI",
+        "gid": "2056967441",
+        "value": "brain-v1.5_DRAFT",
+        "viewValue": "v1.5"
+      } 
     ],
     "title": "Anatomical Structures",
     "data": ""
@@ -276,7 +290,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000970"],
     "version": [
       {
         "sheetId": "1u7IbxnPABRpYL5rFxOba8cmlvG1yGp-dwD3TV3V26K4",
@@ -305,6 +319,12 @@
         "value": "eye-v1.3",
         "viewValue": "v1.3",
         "hraVersion": "v1.4"
+      },
+       {
+        "sheetId": "",
+        "gid": "",
+        "value": "eye-v1.4_DRAFT",
+        "viewValue": "v1.4"
       }
     ],
     "title": "Anatomical Structures",
@@ -319,7 +339,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0003889"],
     "version": [
       {
         "sheetId": "16tAvAmjwKwbq5SDz7UZ-T1N_KUHRGqPDbMqffFuInMI",
@@ -354,7 +374,7 @@
       "width": 600,
       "height": 2500
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000948"],
     "version": [
       {
         "sheetId": "1jVU7LiNjf4X-UzSrFCEkt174NaD423b7fK_4MRItDyg",
@@ -424,6 +444,12 @@
         "value": "kidney-v1.3",
         "viewValue": "v1.3",
         "hraVersion": "v1.4"
+      },
+      {
+        "sheetId": "19B_iDwpVTzLl6JLUl7g943p8b14YxYRwOshm-PLbIwk",
+        "gid": "949267305",
+        "value": "kidney-v1.4_DRAFT",
+        "viewValue": "v1.4"
       }
     ],
     "title": "Anatomical Structures"
@@ -437,7 +463,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0001465"],
     "version": [
       {
         "sheetId": "1QidDho8DxBYjsxaqApiIZA__Z7aWnB61KvC422g2kx8",
@@ -507,27 +533,6 @@
         "gid": "2043181688",
         "value": "large-intestine-v1.4-DRAFT",
         "viewValue": "v1.4 DRAFT"
-      }
-    ],
-    "title": "Anatomical Structures",
-    "data": ""
-  },
-  {
-    "name": "lingual_tonsil",
-    "display": "Lingual Tonsil",
-    "config": {
-      "bimodal_distance_x": 250,
-      "bimodal_distance_y": 60,
-      "width": 700,
-      "height": 2250
-    },
-    "representation_of": [],
-    "version": [
-      {
-        "sheetId": "12YYtvGh7rWhfmzVCbP2iP5FCcmnhOlpwABNcK1wcVBc",
-        "gid": "0",
-        "value": "lingual-tonsil-v1.0-DRAFT",
-        "viewValue": "v1.0 DRAFT"
       }
     ],
     "title": "Anatomical Structures",
@@ -606,13 +611,19 @@
         "value": "lung-v1.3",
         "viewValue": "v1.3",
         "hraVersion": "v1.4"
+      },
+      {
+        "sheetId": "1StCXeg1J9YZaxRb-nnKsso3Dfv5pkH0DxF_8sz_DVMA",
+        "gid": "1109843030",
+        "value": "lung-v1.4_DRAFT",
+        "viewValue": "v1.4"
       }
     ],
     "title": "Anatomical Structures",
     "data": ""
   },
   {
-    "name": "lymph_nodes",
+    "name": "lymph_node",
     "display": "Lymph Node",
     "config": {
       "bimodal_distance_x": 250,
@@ -620,26 +631,26 @@
       "width": 1000,
       "height": 1400
     },
-    "representation_of": ["UBERON: 0000029"],
+    "representation_of": ["UBERON:0000029"],
     "version": [
       {
         "sheetId": "1O30L6BdFUrgDpKXEi1v-t1tD7rxuGfhkE8aaG-uUPdY",
         "gid": "113237877",
-        "value": "lymph_nodes-v1.0",
+        "value": "lymph_node-v1.0",
         "viewValue": "v1.0",
         "hraVersion": "v1.0"
       },
       {
         "sheetId": "1aK9gJ2_kMb2B8zrQgScDgxpEWAcCs7kl-gnQGwV3LHM",
         "gid": "1223566381",
-        "value": "lymph_nodes-v1.1",
+        "value": "lymph_node-v1.1",
         "viewValue": "v1.1",
         "hraVersion": "v1.1"
       },
       {
         "sheetId": "1_VWj_dD1dbmnBf8t0wptXvpy1oyyllZ1tXc0aKo2MSA",
         "gid": "1223566381",
-        "value": "lymph_nodes-v1.2",
+        "value": "lymph_node-v1.2",
         "viewValue": "v1.2",
         "hraVersion": "v1.2,v1.3,v1.4"
       },
@@ -661,7 +672,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0004536"],
     "version": [
       {
         "sheetId": "1SILRNUI71BEVWl1fpsi_32DSuSA-bAPgXv5pTfKnrOE",
@@ -690,7 +701,13 @@
         "value": "lymph-vasculature-v1.3",
         "viewValue": "v1.3",
         "hraVersion": "v1.4"
-      }
+      },
+      {
+        "sheetId": "18Bk3AGcVzabS6DEUZlJzA59lt9q_ZefHJxcklwWqf6M",
+        "gid": "2087685463",
+        "value": "lymph-vasculature-v1.4_DRAFT",
+        "viewValue": "v1.4"
+      }  
     ],
     "title": "Anatomical Structures",
     "data": ""
@@ -704,7 +721,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002182"],
     "version": [
       {
         "sheetId": "1VstIfAHSehrY5MNeTlNtRlOHtbQN8psru5rl5vglPxA",
@@ -712,6 +729,12 @@
         "value": "main-bronchus-v1.0",
         "viewValue": "v1.0",
         "hraVersion": "v1.4"
+      },
+      {
+        "sheetId": "13O5Bb5_ki6uj4NcrFYoZPCHbYwrsPcyPJtdamUeZWZA",
+        "gid": "0",
+        "value": "main-bronchus-v1.1_DRAFT",
+        "viewValue": "v1.1"
       }
     ],
     "title": "Anatomical Structures",
@@ -726,7 +749,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0001911"],
     "version": [
       {
         "sheetId": "1Ac7C4dX7eYSMyR75AA2uVY9ZgNGOZZgbqgR8wmp-wdk",
@@ -747,7 +770,7 @@
       "width": 800,
       "height": 5000
      },
-     "representation_of": [],
+     "representation_of": ["UBERON:0002204"],
      "version": [
        {
          "sheetId": "1UDKjTuDa18kydtOLZr_amdihGWvKs5xzwQ9W_oco3U8",
@@ -755,29 +778,14 @@
          "value": "muscular-system-v1.0",
          "viewValue": "v1.0",
          "hraVersion": "v1.4"
-       }
-     ],
-    "title": "Anatomical Structures",
-    "data": ""
-  },
-  {
-    "name": "nasal_passage",
-    "display": "Nasal Passage",
-    "config": {
-      "bimodal_distance_x": 250,
-      "bimodal_distance_y": 60,
-      "width": 700,
-      "height": 2250
-    },
-    "representation_of": [],
-    "version": [
-      {
-        "sheetId": "1DQst-0PDKXMBS0bvgwOZIfOy274UPOwVe7GIvxLsxpo",
+       },
+       {
+        "sheetId": "1thptktZjTNd2ssJqIbChd01dPdCU1iaO0JmRkU2x80E",
         "gid": "0",
-        "value": "nasal-passage-v1.0-DRAFT",
-        "viewValue": "v1.0 DRAFT"
+        "value": "muscular-system-v1.1_DRAFT",
+        "viewValue": "v1.1"
       }
-    ],
+     ],
     "title": "Anatomical Structures",
     "data": ""
   },
@@ -790,7 +798,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000992"],
     "version": [
       {
         "sheetId": "1FE2XufrruExUWqcai3XRFqtMjeEdzoLKJ-YNa-nRZ1M",
@@ -874,7 +882,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002372"],
     "version": [
       {
         "sheetId": "14VTmaZyxa68uEl9sDKE7N8VBGL8893WlrxnTPBhcjBM",
@@ -895,7 +903,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000010"],
     "version": [
       {
         "sheetId": "1KifiEDn3PpJ8pjz9_ka4TWkT085wLIzIQP5NKSvb2Ac",
@@ -915,27 +923,6 @@
     "data": ""
   },
   {
-    "name": "pharyngeal_tonsil",
-    "display": "Pharyngeal Tonsil",
-    "config": {
-      "bimodal_distance_x": 250,
-      "bimodal_distance_y": 60,
-      "width": 700,
-      "height": 2250
-    },
-    "representation_of": [],
-    "version": [
-      {
-        "sheetId": "1LCYKJzgGf_bP_o6nOkgVHfC7xQL9g77r0HEzJ4dmIlo",
-        "gid": "0",
-        "value": "pharyngeal-tonsil-v1.0-DRAFT",
-        "viewValue": "v1.0 DRAFT"
-      }
-    ],
-    "title": "Anatomical Structures",
-    "data": ""
-  },
-  {
     "name": "placenta full term",
     "display": "Placenta full term",
     "config": {
@@ -944,7 +931,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0001987"],
     "version": [
       {
         "sheetId": "1TqatRIsZZ5QwvWdz6H4Un-sukbzSd21_x41Gqnn5UEY",
@@ -972,7 +959,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002367"],
     "version": [
       {
         "sheetId": "1_O5yXOesG93dobMHRSIvVAt9xj7mDnEAYdRJcHYJ84U",
@@ -1000,7 +987,7 @@
       "width": 600,
       "height": 1000
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0001377"],
     "version": [
       {
         "sheetId": "1fr9d3C2pJNYFvopvPOOSwJjsAaIzRouzuu5daTCd50Y",
@@ -1021,7 +1008,7 @@
       "width": 600,
       "height": 1000
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0004288"],
     "version": [
       {
         "sheetId": "1090VgpMYtAcLPUa_4ITh3hwJBZkQKGKATrZu0hc8EVg",
@@ -1029,6 +1016,12 @@
         "value": "skeleton-v1.0",
         "viewValue": "v1.0",
         "hraVersion": "v1.4"
+      },
+      {
+        "sheetId": "1eJEvULtrtEZWWpZWW2Vu7l7ykgbenm_tv2ZnPlAxs5w",
+        "gid": "0",
+        "value": "skeleton-v1.1_DRAFT",
+        "viewValue": "v1.1"
       }
     ],
     "title": "Anatomical Structures",
@@ -1135,7 +1128,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002240"],
     "version": [
       {
         "sheetId": "1B8Yacpa0S_KuNqGGtKb83HTodKY_XGnIMy8tFCEIEdE",
@@ -1143,6 +1136,12 @@
         "value": "Spinal_Cord-v1.0",
         "viewValue": "v1.0",
         "hraVersion": "v1.4"
+      },
+      {
+        "sheetId": "10stOnKN9uucxrI665_tfu-PWC33E-0HCP1QMdFgYJ0s",
+        "gid": "243784891",
+        "value": "Spinal_Cord-v1.1_DRAFT",
+        "viewValue": "v1.1"
       }
     ],
     "title": "Anatomical Structures",
@@ -1158,7 +1157,7 @@
       "width": 1000,
       "height": 1400
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002106"],
     "version": [
       {
         "sheetId": "1h1YdIyMv5fizD-NfKjaT9DtN5SlHG47LNTRKP5JNVXo",
@@ -1207,7 +1206,7 @@
       "width": 800,
       "height": 1000
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0002370"],
     "version": [
       {
         "sheetId": "14uB40YMrp6hFdf06Vwlqj-Tii3GTdLZyl3n6-sxCsfM",
@@ -1256,7 +1255,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0003126"],
     "version": [
       {
         "sheetId": "1fQK7XcXugC8eJZQyviNLevEUMoDT6cxxWp2AuH2gyws",
@@ -1277,7 +1276,7 @@
       "width": 600,
       "height": 1000
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0001665"],
     "version": [
       {
         "sheetId": "16eZc2yMhnThkQzFYHhiBatbrrh97ywVo2hEP7YbyNc0",
@@ -1298,7 +1297,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000056"],
     "version": [
       {
         "sheetId": "1tK916JyG5ZSXW_cXfsyZnzXfjyoN-8B2GXLbYD6_vF0",
@@ -1326,7 +1325,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0001255"],
     "version": [
       {
         "sheetId": "1ohOG5jMf9d9eqjbVK6_u3CvgfG3wcLfs_pxB2838wOo",
@@ -1354,7 +1353,7 @@
       "width": 700,
       "height": 2250
     },
-    "representation_of": [],
+    "representation_of": ["UBERON:0000995"],
     "version": [
       {
         "sheetId": "1yEcbJMrUIzJY-4JNtF1Y_eUpAQsgKF6DX2-5Z3UXBeE",
@@ -1377,7 +1376,28 @@
         "viewValue": "v1.2 DRAFT"
       }
     ],
-    "title": "Anatomical Structures",
-    "data": ""
+"title": "Anatomical Structures",
+"data": ""
+    },
+    {
+    "name": "white_adipose",
+    "display": "White Adipose",
+    "config": {
+      "bimodal_distance_x": 250,
+      "bimodal_distance_y": 60,
+      "width": 700,
+      "height": 2250
+    },
+"representation_of": ["UBERON:0001347"],
+"version": [
+  {
+    "sheetId": "13ov5MlglQ2mqy8Xl3Hyp4aH2dx1P7Uc4efM4RZqi5DI",
+    "gid": "0",
+    "value": "White-Adipose-v1.0-DRAFT",
+    "viewValue": "v1.0 DRAFT"
   }
+],
+"title": "Anatomical Structures",
+"data": ""
+}
 ]


### PR DESCRIPTION
- added new draft ASCT+B tables to sheetconfig.json
- removed nasal passage, lingual tonsil and pharygeal tonsil as per discussion with katy and bruce that we will not have these tables likely ever, which at the original time of creation was not clear.
- added uberon ids for all representation of sections; most were missing. NOTE: large and small intestine are mapping to intestine uberon id so they match OMAP for combined intestines rather than to large or small intestine directly.
- found and removed space between uberon: and the number for lymph node
- added new anatomical systems table which will allow a table for pulling in all the organ tables into the unity of the body in lieu of physiological systems table.  Griffin suggested this; seems like a great way to unify.
